### PR TITLE
Tooltip redux

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -34,6 +34,24 @@ body, p {
   width: 10px;
 }
 
+.maplibregl-popup-content {
+  width: 400px !important;
+}
+
+.info {
+    padding: 6px 8px;
+    margin: 5px;
+    font: 14px/16px Arial, Helvetica, sans-serif;
+    background: white;
+    /*background: rgba(255,255,255,0.8);*/
+    box-shadow: 0 0 15px rgba(0,0,0,0.2);
+    border-radius: 5px;
+}
+.info h4 {
+    margin: 0 0 5px;
+    color: #777;
+}
+
 .custom-nav a {
   padding-right: 20px;
 }

--- a/css/custom.css
+++ b/css/custom.css
@@ -43,7 +43,6 @@ body, p {
     margin: 5px;
     font: 14px/16px Arial, Helvetica, sans-serif;
     background: white;
-    /*background: rgba(255,255,255,0.8);*/
     box-shadow: 0 0 15px rgba(0,0,0,0.2);
     border-radius: 5px;
 }

--- a/js/map.js
+++ b/js/map.js
@@ -174,6 +174,14 @@ function updateLegend(layerSource, category, status){
   $('#solar-legend').html(legendText)
 }
 
+function resetClickedState(){
+  // reset the previous clicked feature
+  map.setFeatureState(
+    { source: selectedGeography, id: selectedId },
+    { clicked: false }
+  )
+}
+
 function getFillColor(layerSource, category, status){
   let var_prefix = ""
   let colors = energized_colors
@@ -331,25 +339,20 @@ function addLayer(map, layerSource, visible = 'none'){
 
   map.on('click', `${layerSource}-fills`, (e) => {
     const feat = e.features[0]
-
-    // reset the previous clicked feature
-    map.setFeatureState(
-      { source: layerSource, id: selectedId },
-      { clicked: false }
-    )
-
+    resetClickedState()
     selectedId = feat.id
     $.address.parameter('id', selectedId)
     featureClicked(feat, e.lngLat)
   })
 }
 
-function showLayer(selectedGeography, selectedCategory, selectedStatus) {
+function showLayer(selectedGeography, selectedCategory, selectedStatus) {  
   map.setLayoutProperty(selectedGeography + '-fills', 'visibility', 'visible')
   map.setLayoutProperty(selectedGeography + '-outline', 'visibility', 'visible')
   map.setPaintProperty(selectedGeography + '-fills', 'fill-color', getFillColor(selectedGeography, selectedCategory, selectedStatus))
   updateLegend(selectedGeography, selectedCategory, selectedStatus)
 
+  // remove previous popup
   if (popup) {
     popup.remove()
     $.address.parameter('id', null)
@@ -422,6 +425,7 @@ map.on('load', () => {
     hideLayers(['tracts-fills','places-fills','counties-fills','il-senate-fills','il-house-fills'])
     hideLayers(['tracts-outline','places-outline','counties-outline','il-senate-outline','il-house-outline'])
     
+    resetClickedState()
     selectedGeography = this.value
     $.address.parameter('geography', selectedGeography)
     


### PR DESCRIPTION
## Overview

Updates the map interface to support click interactions and now saves state in the URL for easier sharing. The popups allow text to be easier to read and copy/paste over the hover, that updates whenever the mouse moves.

- clicking a feature shows a popup tooltip
- hovering over a feature updates a simple info box in the lower left corner
- clicking a feature saves the ID to the URL. loading from that URL clicks the feature on load

Related to #78. This likely eliminates/reduces the need for creating detail pages.

Examples:

* https://deploy-preview-82--il-solar-map.netlify.app/#/?id=17045070200
* https://deploy-preview-82--il-solar-map.netlify.app/#/?category=utility_kw&status=planned&id=17019010800
* https://deploy-preview-82--il-solar-map.netlify.app/#/?category=total_kw&status=energized&geography=places&id=53886039

### Demo

![Screenshot 2025-05-01 at 4 59 27 PM](https://github.com/user-attachments/assets/7b789537-50d3-4016-a25c-1a9421010c9d)

## Testing Instructions

* toggle hover and click on the map and confirm features work as expected
* reload the page and confirm the selected feature is still shown
* save a few URLs and confirm it loads the selected feature and layer
